### PR TITLE
Add crashinfo.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ server_log.txt
 #
 
 *.sublime-workspace
+
+# SAMP default crash dump
+crashinfo.txt


### PR DESCRIPTION
crashinfo.txt can now be created inside the package's folder when pawn.json's local is set to true